### PR TITLE
Add env-based DB configuration

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -9,6 +9,12 @@ NODE_ENV=development
 PORT=3001
 HOST=localhost
 DATABASE_URL=postgresql://username:password@localhost:5432/chatapp
+# Optional individual database settings (used if DATABASE_URL is not set)
+DB_HOST=localhost
+DB_PORT=5432
+DB_NAME=chatapp
+DB_USER=username
+DB_PASSWORD=password
 SUPABASE_URL=your_supabase_url
 SUPABASE_SERVICE_KEY=your_supabase_service_key
 JWT_SECRET=your_super_secret_jwt_key_here

--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ cp .env.example .env
 
 # 编辑环境变量
 # 配置数据库连接、JWT密钥等
+# 如果未设置 `DATABASE_URL`，可使用 `DB_HOST`、`DB_PORT`、`DB_NAME`、`DB_USER`、`DB_PASSWORD` 单独配置数据库
 ```
 
 4. **数据库设置**

--- a/server/src/config/database.ts
+++ b/server/src/config/database.ts
@@ -4,9 +4,18 @@ declare global {
   var __prisma: PrismaClient | undefined
 }
 
+// Resolve database connection URL
+let databaseUrl = process.env.DATABASE_URL
+if (!databaseUrl && process.env.DB_HOST && process.env.DB_PORT && process.env.DB_USER && process.env.DB_PASSWORD && process.env.DB_NAME) {
+  const { DB_HOST, DB_PORT, DB_USER, DB_PASSWORD, DB_NAME } = process.env
+  const encodedPass = encodeURIComponent(DB_PASSWORD)
+  databaseUrl = `postgresql://${DB_USER}:${encodedPass}@${DB_HOST}:${DB_PORT}/${DB_NAME}`
+}
+
 // Prevent multiple instances of Prisma Client in development
 const prisma = globalThis.__prisma || new PrismaClient({
   log: process.env.NODE_ENV === 'development' ? ['query', 'error', 'warn'] : ['error'],
+  datasources: databaseUrl ? { db: { url: databaseUrl } } : undefined,
 })
 
 if (process.env.NODE_ENV === 'development') {


### PR DESCRIPTION
## Summary
- allow customizing Prisma datasource URL from individual DB_* env variables
- document new environment variables for database configuration

## Testing
- `npm test` *(fails: No test files found)*

------
https://chatgpt.com/codex/tasks/task_b_6869c99d28988322a3380f94d2afe7c0